### PR TITLE
完善 Docker 部署配置，修复打包 bug 并支持前后端一键上云

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -1,16 +1,16 @@
 [service]
 AppMode = debug
-HttpPort = :3000
+HttpPort = :8080
 
 [redis]
 RedisDb = redis
-RedisAddr = localhost:6379
+RedisAddr = redis:6379
 RedisPw =
 RedisDbName = 2
 
 [mysql]
 Db = mysql
-DbHost = localhost
+DbHost = mysql
 DbPort = 3306
 DbUser = todolist
 DbPassWord = todolist


### PR DESCRIPTION
感谢作者提供的优秀开源项目！🎉

最近在尝试将本后端项目与对应的前端项目（[CocaineCong/react-todolist](https://github.com/CocaineCong/react-todolist)）联合部署到云服务器时，发现直接使用原有的 Docker 配置会遇到一些环境报错和网络问题。

为了方便后续学习的新手能够更顺畅地实现**“前端 + 后端 + 数据库”的全栈一键上云部署**，我在此基础上进行了排错和配置完善。

🐛 修复的 Bug
目录拼写错误：修复了 Dockerfile 中 cp -r conf publish 报错找不到目录的问题，实际的项目配置目录名为 config，已将其修正。

架构不兼容：原 Dockerfile 中硬编码了 GOARCH=arm64，导致在主流的 x86_64 云服务器上运行报错，已修改为更通用的 amd64。

✨ 新增与优化的配置
新增容器编排：增加了完整的 docker-compose.yml 文件。直接拉起 Go 后端程序、MySQL（含 config/sql 初始化脚本挂载和数据持久卷）以及 Redis 缓存，真正实现一条命令 docker-compose up -d --build 跑通后端全家桶。

打通容器网络：修改了 config/config.ini.example 模板文件，将 MySQL 和 Redis 的连接地址从 localhost 调整为了 docker-compose 中对应的服务名（mysql 和 redis），解决了容器间的网络通信问题。

测试环境：Ubuntu 20.04/22.04 LTS
经过以上修改，目前前后端已经可以在云服务器上完美联调运行。希望这个小优化能帮到更多学习这个项目的朋友！